### PR TITLE
Add cloud plugin

### DIFF
--- a/LevelEditorMod/Editor/Entities/Plugin_Cloud.cs
+++ b/LevelEditorMod/Editor/Entities/Plugin_Cloud.cs
@@ -1,0 +1,18 @@
+﻿using Celeste;
+
+namespace LevelEditorMod.Editor.Entities {
+
+    [Plugin("cloud")]
+    public class Plugin_Cloud : Entity {
+
+        [Option("fragile")] public bool Fragile = false;
+
+        public override void Render() {
+            base.Render();
+            
+            string type = Fragile ? "fragile" : "cloud";
+            string suffix = Room.Map.Mode == AreaMode.Normal ? "" : "Remix";
+            GFX.Game[$"objects/clouds/{type}{suffix}00"].DrawCentered(Position);
+        }
+    }
+}

--- a/LevelEditorMod/Editor/Map.cs
+++ b/LevelEditorMod/Editor/Map.cs
@@ -10,6 +10,7 @@ namespace LevelEditorMod.Editor {
         private readonly List<Rectangle> fillers = new List<Rectangle>();
 
         public readonly string Name;
+        public readonly AreaMode Mode;
 
         internal Map(string name) {
             Name = name;
@@ -18,9 +19,10 @@ namespace LevelEditorMod.Editor {
         internal Map(MapData data)
             : this(data.Filename) {
             foreach (LevelData roomData in data.Levels)
-                rooms.Add(new Room(roomData));
+                rooms.Add(new Room(roomData, this));
             foreach (Rectangle filler in data.Filler)
                 fillers.Add(filler);
+            Mode = data.Area.Mode;
         }
 
         internal Room GetRoomAt(Point at) {

--- a/LevelEditorMod/Editor/Room.cs
+++ b/LevelEditorMod/Editor/Room.cs
@@ -13,6 +13,8 @@ namespace LevelEditorMod.Editor {
 
         public Rectangle Bounds { get; private set; }
 
+        public Map Map { get; private set; }
+
         public int X => Bounds.X;
         public int Y => Bounds.Y;
         public int Width => Bounds.Width;
@@ -51,8 +53,9 @@ namespace LevelEditorMod.Editor {
             bgTileMap = new VirtualMap<char>(bounds.Width, bounds.Height, '0');
         }
 
-        internal Room(LevelData data)
+        internal Room(LevelData data, Map map)
             : this(data.Name, data.TileBounds) {
+            Map = map;
             // BgTiles
             string[] array = tileSplitter.Split(data.Bg);
             for (int i = 0; i < array.Length; i++) {

--- a/LevelEditorMod/LevelEditorMod.csproj
+++ b/LevelEditorMod/LevelEditorMod.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Editor\Entities\Plugin_FloatingDebris.cs" />
     <Compile Include="Editor\Entities\Plugin_FlutterBird.cs" />
     <Compile Include="Editor\Entities\Plugin_ForegroundDebris.cs" />
+    <Compile Include="Editor\Entities\Plugin_Cloud.cs" />
     <Compile Include="Editor\Entities\Plugin_GoldenBerry.cs" />
     <Compile Include="Editor\Entities\Plugin_JumpThru.cs" />
     <Compile Include="Editor\Entities\Plugin_Key.cs" />


### PR DESCRIPTION
displays normal and fragile clouds, and displays small clouds in b-sides/c-sides.

this also adds a reference to the current Map in Room, and the current AreaMode in Map, for the latter to work.