### PR TITLE
Brush tool fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+.idea

--- a/source/Editor/Editor.cs
+++ b/source/Editor/Editor.cs
@@ -291,7 +291,7 @@ namespace Snowberry.Editor {
             MouseState m = Microsoft.Xna.Framework.Input.Mouse.GetState();
             Vector2 mouseVec = new Vector2(m.X, m.Y);
             Mouse.Screen = mouseVec / 2;
-            Mouse.World = Calc.Round(Vector2.Transform(Camera.Buffer == null ? mouseVec : mousePos, Camera.Inverse));
+            Mouse.World = Vector2.Transform(Camera.Buffer == null ? mouseVec : mousePos, Camera.Inverse).Floor();
 
             MouseClicked = false;
             ui.Update();

--- a/source/Editor/Tools/TileBrushTool.cs
+++ b/source/Editor/Tools/TileBrushTool.cs
@@ -234,7 +234,7 @@ namespace Snowberry.Editor.Tools {
                 int x = (int)tilePos.X; int y = (int)tilePos.Y;
                 if (Editor.SelectedRoom.Bounds.Contains((int)(x + Editor.SelectedRoom.Position.X), (int)(y + Editor.SelectedRoom.Position.Y))) {
                     var lastPress = (Editor.Instance.worldClick / 8).Floor();
-                    var roomLastPress = (Editor.Instance.worldClick / 8).Floor() - Editor.SelectedRoom.Position;
+                    var roomLastPress = lastPress - Editor.SelectedRoom.Position;
                     int ax = (int)Math.Min(x, roomLastPress.X);
                     int ay = (int)Math.Min(y, roomLastPress.Y);
                     int bx = (int)Math.Max(x, roomLastPress.X);
@@ -319,9 +319,11 @@ namespace Snowberry.Editor.Tools {
                             }
                             break;
                         case TileBrushMode.Circle:
+                            int radiusSquared = (rect.Width - 1) * (rect.Width - 1) + (rect.Height - 1) * (rect.Height - 1);
                             for (int x2 = 0; x2 < holoFgTileMap.Columns; x2++)
                                 for (int y2 = 0; y2 < holoFgTileMap.Rows; y2++) {
-                                    bool set = ((lastPress.X - x2) * (lastPress.X - x2) + (lastPress.Y - y2) * (lastPress.Y - y2)) < (rect.Width * rect.Width + rect.Height * rect.Height) / Math.Sqrt(2);
+                                    float deltaSquared = (roomLastPress.X - x2) * (roomLastPress.X - x2) + (roomLastPress.Y - y2) * (roomLastPress.Y - y2);
+                                    bool set = deltaSquared <= radiusSquared;
                                     SetHoloTile(fg, set ? tileset : 0, x2, y2, !set);
                                 }
                             break;

--- a/source/Editor/Tools/TileBrushTool.cs
+++ b/source/Editor/Tools/TileBrushTool.cs
@@ -233,8 +233,8 @@ namespace Snowberry.Editor.Tools {
                 var tilePos = new Vector2((float)Math.Floor(Editor.Mouse.World.X / 8 - Editor.SelectedRoom.Position.X), (float)Math.Floor(Editor.Mouse.World.Y / 8 - Editor.SelectedRoom.Position.Y));
                 int x = (int)tilePos.X; int y = (int)tilePos.Y;
                 if (Editor.SelectedRoom.Bounds.Contains((int)(x + Editor.SelectedRoom.Position.X), (int)(y + Editor.SelectedRoom.Position.Y))) {
-                    var lastPress = (Editor.Instance.worldClick / 8).Ceiling();
-                    var roomLastPress = (Editor.Instance.worldClick / 8).Ceiling() - Editor.SelectedRoom.Position;
+                    var lastPress = (Editor.Instance.worldClick / 8).Floor();
+                    var roomLastPress = (Editor.Instance.worldClick / 8).Floor() - Editor.SelectedRoom.Position;
                     int ax = (int)Math.Min(x, roomLastPress.X);
                     int ay = (int)Math.Min(y, roomLastPress.Y);
                     int bx = (int)Math.Max(x, roomLastPress.X);

--- a/source/Editor/Tools/TileBrushTool.cs
+++ b/source/Editor/Tools/TileBrushTool.cs
@@ -239,7 +239,7 @@ namespace Snowberry.Editor.Tools {
                     int ay = (int)Math.Min(y, roomLastPress.Y);
                     int bx = (int)Math.Max(x, roomLastPress.X);
                     int by = (int)Math.Max(y, roomLastPress.Y);
-                    var rect = new Rectangle(ax, ay, bx - ax, by - ay);
+                    var rect = new Rectangle(ax, ay, bx - ax + 1, by - ay + 1);
                     TileBrushMode mode = left ? LeftMode : RightMode;
                     switch (mode) {
                         case TileBrushMode.Brush:


### PR DESCRIPTION
* Fixes brushes snapping one tile too far right and down
* Ensure brushes are always at least 1 tile in size
* Fixes circle tool only working in first room
* Fixes mouse world vector being one pixel off due to `Math.Round` not being quite what we want